### PR TITLE
Update extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,7 +105,7 @@ function createOverlay() {
   
   // check gnome version to determine correct call to create new overlay 
   if (gnome_at_least_3_38) {
-    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_expand: true, y_expand: false, track_hover: true });
+    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, track_hover: true });
   } else {
     overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_fill: true, y_fill: false, track_hover: true });
   };

--- a/extension.js
+++ b/extension.js
@@ -105,7 +105,7 @@ function createOverlay() {
   
   // check gnome version to determine correct call to create new overlay 
   if (gnome_at_least_3_38) {
-    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, track_hover: true });
+    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_expand: true, y_expand: false, track_hover: true });
   } else {
     overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_fill: true, y_fill: false, track_hover: true });
   };

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 const St = imports.gi.St;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+//const Tweener = imports.ui.tweener; //not referenced anywhere in file and apparently not needed. commented out for 3.38 compatibility
 const Shell = imports.gi.Shell;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -46,6 +46,9 @@ function init() {
   modifier_key = setting.get_int('modifier-key');
   Log.debug("Gnome version:" + imports.misc.config.PACKAGE_VERSION);
   gnome_at_least_3_34 = isVersionGreaterOrEqual(3, 34);
+  // gnome 3.38 includes syntax changes to creating new overlay. 
+  // this will be used later to decide which method to use in createOverlay 
+  gnome_at_least_3_38 = isVersionGreaterOrEqual(3, 38);
 }
 
 function getMouseHoveredWindowActor() {
@@ -99,13 +102,13 @@ function createOverlay() {
   });
   overlayContainer.add_constraint(new Layout.MonitorConstraint({primary: true, work_area: true}));
   Main.layoutManager.addChrome(overlayContainer, {affectsInputRegion: false});
-
-  overlay = new St.Bin({ style_class: '',
-    reactive: true,
-    can_focus: true,
-    x_fill: true,
-    y_fill: false,
-    track_hover: true });
+  
+  // check gnome version to determine correct call to create new overlay 
+  if (gnome_at_least_3_38) {
+    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_expand: true, y_expand: false, track_hover: true });
+  } else {
+    overlay = new St.Bin({ style_class: '', reactive: true, can_focus: true, x_fill: true, y_fill: false, track_hover: true });
+  };
   //TODO:support multi-monitor
   let monitor = Main.layoutManager.primaryMonitor;
   overlay.set_size(monitor.width, monitor.height);

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,10 @@
   "settings-schema": "org.gnome.shell.extensions.TransparentWindow",
   "shell-version": [
     "3.28.1",
-    "3.36.1"
+    "3.36.1",
+    "3.38.1"
   ],
   "url": "https://github.com/pbxqdown/gnome-shell-extension-transparent-window",
   "uuid": "transparent-window@pbxqdown.github.com",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Removed import of import.ui.tweener. The imported constant didn't appear to be referenced anywhere in the code and Gnome 3.38 changed the location to import.tweener.tweener. Because there don't appear to be any references, I have removed the import instead of getting into the complexity of checking Gnome version to determine which import to use.

Added a constant gnome_at_least_3_38 which is used later in the createOverlay function.

Updated the createOverlay function so that it checks gnome_at_least_3_38 to determine which syntax to use to call new StBin() to create the new overlay.

I've tested Gnome 3.38 on ArchLinux  EndeavourOS and can't find anything that isn't working as expected.

PS - You might want to update metadata.json to add Gnome 3.38 to the version list.

Addressed issue #8 