### PR TITLE
fix: also ignore Num_Lock state

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,7 +128,6 @@ function destroyOverlay() {
 
 function onHotkeyPressed() {
   Log.debug("Hot key pressed");
-  //Clear the lock bit so the status of Caps_Lock won't affect the functionality
   const multiKeysCode = getMultiKeysCode(keymap);
   Log.debug(multiKeysCode);
   switch(multiKeysCode) {

--- a/extension.js
+++ b/extension.js
@@ -21,6 +21,7 @@ let setting;
 
 const Utils = Me.imports.utils;
 const isVersionGreaterOrEqual = Utils.isVersionGreaterOrEqual;
+const getMultiKeysCode = Utils.getMultiKeysCode;
 
 let text, button, settings, win_actor, overlayContainer, overlay, sig_scroll, keymap, sig_keymap;
 let step = 5;
@@ -128,7 +129,7 @@ function destroyOverlay() {
 function onHotkeyPressed() {
   Log.debug("Hot key pressed");
   //Clear the lock bit so the status of Caps_Lock won't affect the functionality
-  let multiKeysCode = keymap.get_modifier_state() & (~2);
+  const multiKeysCode = getMultiKeysCode(keymap);
   Log.debug(multiKeysCode);
   switch(multiKeysCode) {
     case modifier_key:

--- a/prefs.js
+++ b/prefs.js
@@ -17,6 +17,7 @@ const Gdk = imports.gi.Gdk;
 
 const Utils = Me.imports.utils;
 const isVersionGreaterOrEqual = Utils.isVersionGreaterOrEqual;
+const getMultiKeysCode = Utils.getMultiKeysCode;
 
 let ModifierKeyWidget;
 let startTime = 0;
@@ -45,7 +46,7 @@ function init(){
 }
 
 function onHotkeyPressed() {
-  let multiKeysCode = keymap.get_modifier_state() & (~2);
+  const multiKeysCode = getMultiKeysCode(keymap);
   //new keystroke series coming out, reset startTime and max keyscode
   if(Date.now() - startTime > 500) {
     startTime = Date.now();

--- a/utils.js
+++ b/utils.js
@@ -7,3 +7,7 @@ function isVersionGreaterOrEqual(major, minor) {
     if (parseInt(lis[1]) < minor) return false;
     return true;
 }
+
+function getMultiKeysCode(keymap) {
+    return keymap.get_modifier_state() & (~(2 | 16));
+}

--- a/utils.js
+++ b/utils.js
@@ -8,6 +8,8 @@ function isVersionGreaterOrEqual(major, minor) {
     return true;
 }
 
+//Clear the lock bit so the status of Caps_Lock won't affect the functionality
+//~2(caps_lock) and ~16(num_lock)
 function getMultiKeysCode(keymap) {
     return keymap.get_modifier_state() & (~(2 | 16));
 }


### PR DESCRIPTION
This is a fix for https://github.com/pbxqdown/gnome-shell-extension-transparent-window/pull/19 because it was not done.