### PR TITLE
fix: use scroll delta when SMOOTH scroll direction reported

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -71,14 +71,23 @@ function onScroll(actor, event) {
   let opacity = win_actor.get_opacity();
 
   let dir = event.get_scroll_direction();
-  Log.debug(dir);
+  Log.debug("dir: " + dir);
+
   switch(dir) {
     case Clutter.ScrollDirection.UP:
       opacity += step;
       break;
+
     case Clutter.ScrollDirection.DOWN:
       opacity -= step;
       break;
+
+    case Clutter.ScrollDirection.SMOOTH:
+      let [,ydelta] = event.get_scroll_delta();
+      Log.debug("delta: " + ydelta);
+      opacity -= step * ydelta;
+      break;
+
     default:
       return Clutter.EVENT_PROPAGATE;
   }


### PR DESCRIPTION
On my machine the extension wasn't working and it turns out that the scroll direction reported was Clutter.ScrollDirection.SMOOTH

This was on Gnome v42.9 with an external USB mouse.